### PR TITLE
feat: [P4ADEV-165] header component

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mui/material';
 import React from 'react';
-import style from '../../src/utils/style';
 
-export const Footer = () => <Box height={style.footer.height}>footer</Box>;
+export const Footer = () => <Box>footer</Box>;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,26 @@
-import { Box } from '@mui/material';
 import React from 'react';
-import style from '../../src/utils/style';
+import { HeaderAccount, HeaderProduct, JwtUser } from '@pagopa/mui-italia';
+import utils from 'src/utils';
 
-export const Header = () => <Box height={style.header.height}>Header</Box>;
+/*
+User info
+*/
+const mockUser: JwtUser = {
+  id: '1',
+  name: 'John',
+  surname: 'Doe',
+  email: 'john.doe@gmail.com'
+};
+
+export const Header = () => (
+  <>
+    <HeaderAccount
+      rootLink={utils.config.pagopaLink}
+      enableDropdown
+      onAssistanceClick={() => null}
+      loggedUser={mockUser}
+      userActions={utils.config.userActions}
+    />
+    <HeaderProduct productsList={[utils.config.product]} />
+  </>
+);

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -19,7 +19,7 @@ export function Layout({ children }: LayoutProps) {
           <Header />
         </Grid>
         <Sidebar />
-        <Grid item bgcolor={grey['100']} padding={4}>
+        <Grid item bgcolor={grey['100']} padding={4} xs>
           {children}
         </Grid>
         <Grid item xs={12}>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -34,7 +34,8 @@ export const Sidebar = () => {
         flexDirection={'column'}
         item
         minHeight={'50vh'}
-        xs={collapsed ? 'auto' : 3}>
+        xs={collapsed ? 'auto' : 3}
+        sx={{ bgcolor: 'background.paper' }}>
         <List role="navigation" component="nav" aria-label={t('menu.description')}>
           {menuItems.map((item: ISidebarMenuItem, index: number) => (
             <SidebarMenuItem collapsed={collapsed} item={item} key={index}></SidebarMenuItem>

--- a/src/utils/config.tsx
+++ b/src/utils/config.tsx
@@ -1,0 +1,51 @@
+import { ProductEntity, RootLinkType, UserAction } from '@pagopa/mui-italia';
+/* Icons */
+import SettingsIcon from '@mui/icons-material/Settings';
+import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
+
+type Config = {
+  product: ProductEntity;
+  pagopaLink: RootLinkType;
+  userActions: UserAction[];
+};
+
+const product: ProductEntity = {
+  id: '0',
+  title: `Area Riservata Cittadini`,
+  productUrl: '#area-riservata-cittadini',
+  linkType: 'external'
+};
+
+const pagopaLink: RootLinkType = {
+  label: 'PagoPA S.p.A.',
+  href: 'https://www.pagopa.it/',
+  ariaLabel: 'Link: vai al sito di PagoPA S.p.A.',
+  title: 'Sito di PagoPA S.p.A.'
+};
+
+const userActions: UserAction[] = [
+  {
+    id: 'profile',
+    label: 'I tuoi dati',
+    onClick: () => {
+      console.log('Clicked/Tapped on Profile');
+    },
+    icon: <SettingsIcon fontSize="small" color="inherit" />
+  },
+  {
+    id: 'logout',
+    label: 'Esci',
+    onClick: () => {
+      console.log('User logged out');
+    },
+    icon: <LogoutRoundedIcon fontSize="small" color="inherit" />
+  }
+];
+
+const config: Config = {
+  product,
+  pagopaLink,
+  userActions
+};
+
+export default config;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,7 @@
+import style from './style';
+import config from './config';
+
+export default {
+  style,
+  config
+};

--- a/src/utils/style.tsx
+++ b/src/utils/style.tsx
@@ -34,13 +34,7 @@ const customTheme = createTheme({
 });
 
 const style = {
-  theme: customTheme,
-  header: {
-    height: 122
-  },
-  footer: {
-    height: 158
-  }
+  theme: customTheme
 };
 
 export const Theme = (props: PropsWithChildren) => (


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
With this PR the Header componet taken from mui library is introduced in the main layout. 
It's a static component without logic and it will be necessary to introduce them in a more advanced phase of the project (
e.g: by valorising the username when we have the login functionality available)

#### Motivation and Context
Of course the Header component is a required one and needs to be introduced
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested running the FE locally and comparing it with its relative design

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
![image](https://github.com/pagopa/pagopa-arc-fe/assets/34749257/b5745453-596d-451b-86c0-2e1d8bc7d9e3)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
