### PR TITLE
feat: [P4PU-178] payment notice preview

### DIFF
--- a/src/components/PaymentNotice/PaymentNotice.tsx
+++ b/src/components/PaymentNotice/PaymentNotice.tsx
@@ -1,0 +1,4 @@
+import { _Preview } from './Preview';
+
+export const PaymentNotice = () => {};
+PaymentNotice.Preview = _Preview;

--- a/src/components/PaymentNotice/Preview.test.tsx
+++ b/src/components/PaymentNotice/Preview.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { PaymentNotice } from './index';
+import i18n from 'translations/i18n';
+
+void i18n.init({
+  resources: {}
+});
+
+jest.mock('@pagopa/mui-italia', () => ({
+  IllusSharingInfo: jest.fn(() => <div>Illustration</div>)
+}));
+
+describe('PaymentNotice.Preview Component', () => {
+  const renderWithTheme = (ui: React.ReactElement) => {
+    const theme = createTheme();
+    return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+  };
+
+  it('renders the title and description', () => {
+    renderWithTheme(<PaymentNotice.Preview />);
+
+    expect(screen.getByText('app.paymentNotice.preview.title')).toBeInTheDocument();
+    expect(screen.getByText('app.paymentNotice.preview.description')).toBeInTheDocument();
+  });
+
+  it('renders the action button', () => {
+    renderWithTheme(<PaymentNotice.Preview />);
+
+    expect(screen.getByText('app.paymentNotice.preview.action')).toBeInTheDocument();
+  });
+
+  it('renders the illustration on large screens', () => {
+    renderWithTheme(<PaymentNotice.Preview />);
+
+    // Simulate a large screen
+    window.matchMedia = jest.fn().mockImplementation((query) => ({
+      matches: query.includes('min-width'),
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn()
+    }));
+
+    renderWithTheme(<PaymentNotice.Preview />);
+
+    expect(screen.getByText('Illustration')).toBeInTheDocument();
+  });
+
+  it('does not render the illustration on small screens', () => {
+    // Simulate a small screen
+    window.matchMedia = jest.fn().mockImplementation((query) => ({
+      matches: !query.includes('min-width'),
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn()
+    }));
+
+    renderWithTheme(<PaymentNotice.Preview />);
+
+    expect(screen.queryByText('Illustration')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/PaymentNotice/Preview.tsx
+++ b/src/components/PaymentNotice/Preview.tsx
@@ -1,0 +1,34 @@
+import { Box, Button, Theme, useMediaQuery } from '@mui/material';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { IllusSharingInfo } from '@pagopa/mui-italia';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export const _Preview = () => {
+  const { t } = useTranslation();
+  const mdUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
+
+  return (
+    <Stack
+      sx={{ backgroundColor: 'background.paper' }}
+      justifyContent="space-between"
+      direction="row"
+      borderRadius={4}
+      gap={3}
+      padding={3}>
+      <Stack spacing={3}>
+        <Stack gap={1}>
+          <Typography variant="h6">{t('app.paymentNotice.preview.title')}</Typography>
+          <Typography>{t('app.paymentNotice.preview.description')}</Typography>
+        </Stack>
+        <Box display="flex" justifyContent={{ xs: 'stretch', sm: 'flex-start' }}>
+          <Button size="large" variant="contained">
+            {t('app.paymentNotice.preview.action')}
+          </Button>
+        </Box>
+      </Stack>
+      {mdUp && <IllusSharingInfo size={120} />}
+    </Stack>
+  );
+};

--- a/src/components/PaymentNotice/index.tsx
+++ b/src/components/PaymentNotice/index.tsx
@@ -1,0 +1,1 @@
+export { PaymentNotice } from './PaymentNotice';

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -8,6 +8,7 @@ import { ArcRoutes } from './routes';
 import { grey } from '@mui/material/colors';
 import Transactions from 'components/Transactions/Transactions';
 import QueryLoader from 'components/QueryLoader';
+import { PaymentNotice } from 'components/PaymentNotice';
 
 const Dashboard = () => {
   const { t } = useTranslation();
@@ -42,23 +43,24 @@ const Dashboard = () => {
           {t('app.dashboard.newPayment')}
         </Button>
       </Stack>
-      <Stack mb={3}>
+      <Stack gap={5}>
         <IOAlert />
-      </Stack>
-      <Stack
-        direction={{ sm: 'row' }}
-        justifyContent="space-between"
-        alignItems={{ sm: 'center' }}
-        mb={2}>
-        <Typography variant="h6" component="h2" marginInlineStart={{ xs: 1, sm: 0 }}>
-          {t('app.dashboard.lastTransactions')}
-        </Typography>
-        <Button
-          component={Link}
-          to={ArcRoutes.TRANSACTIONS}
-          sx={{ width: theme.spacing(10), justifyContent: 'flex-start' }}>
-          {t('app.dashboard.seeAllTransactions')}
-        </Button>
+        <PaymentNotice.Preview />
+        <Stack
+          direction={{ sm: 'row' }}
+          justifyContent="space-between"
+          alignItems={{ sm: 'center' }}
+          mb={2}>
+          <Typography variant="h6" component="h2" marginInlineStart={{ xs: 1, sm: 0 }}>
+            {t('app.dashboard.lastTransactions')}
+          </Typography>
+          <Button
+            component={Link}
+            to={ArcRoutes.TRANSACTIONS}
+            sx={{ width: theme.spacing(10), justifyContent: 'flex-start' }}>
+            {t('app.dashboard.seeAllTransactions')}
+          </Button>
+        </Stack>
       </Stack>
       <Box
         bgcolor={grey['A200']}

--- a/src/stories/PaymentNotice.stories.tsx
+++ b/src/stories/PaymentNotice.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PaymentNotice } from 'components/PaymentNotice';
+
+const meta: Meta<typeof PaymentNotice.Preview> = {
+  title: 'PaymentNotice',
+  parameters: {
+    backgrounds: {
+      default: 'paper',
+      values: [
+        { name: 'paper', value: '#f5f5f5' },
+        { name: 'black', value: 'black' }
+      ]
+    }
+  }
+};
+
+export default meta;
+type StoryTabs = StoryObj<typeof PaymentNotice.Preview>;
+
+export const Preview: StoryTabs = {
+  render: PaymentNotice.Preview
+};

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -53,7 +53,13 @@
       "payed": "Pagato",
       "viewDetail": "Visualizza il dettaglio per la transazione"
     },
-
+    "paymentNotice": {
+      "preview": {
+        "title": "Cerca i tuoi avvisi di pagamento pagoPA",
+        "description": "Qui puoi trovare gli avvisi da pagare a tuo nome predisposti dagli enti aderenti al servizio",
+        "action": "Cerca i tuoi avvisi"
+      }
+    },
     "routes": {
       "back": "Indietro",
       "breadcrumbs": "breadcrumbs",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- PaymentNotice.Preview component
- Adds PaymentNotice.Preview to dashboard page
- PaymentNotice.Preview stories
- PaymentNotice.Preview unit tests
- PaymentNotice.Preview i18n for 'it' locale
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pr creates the PaymentNotice.Preview component and related stories.
This component is rendered inside the Dashboard route.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Visual Testing
- Storybook
- Unit tests
#### Screenshots (if appropriate):
![image](https://github.com/pagopa/pagopa-arc-fe/assets/61319404/98014e59-65d8-49df-ad1b-e667e8134cc0)
![image](https://github.com/pagopa/pagopa-arc-fe/assets/61319404/7bac9aee-15a7-4042-a535-8d74afaaf9f7)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
