### PR TITLE
feat: [P4PU-180] payment notices route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { HealthCheck } from 'components/HealthCheck';
 import { CourtesyPage } from 'routes/CourtesyPage';
 import Login from 'routes/Login';
 import Assistance from 'routes/Assistance';
+import { PaymentNotices } from 'routes/PaymentNotices';
 
 const router = createBrowserRouter([
   {
@@ -91,6 +92,11 @@ const router = createBrowserRouter([
         path: ArcRoutes.TRANSACTIONS,
         element: <TransactionsList />,
         // TEMPORARY ERROR ELEMENT
+        errorElement: <ErrorFallback />
+      },
+      {
+        path: ArcRoutes.PAYMENT_NOTICES,
+        element: <PaymentNotices />,
         errorElement: <ErrorFallback />
       }
     ]

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -41,7 +41,13 @@ export function Layout() {
             }}
           />
         </Grid>
-        <Grid item display={'flex'} flexGrow={1} alignContent={'flex-start'} flexBasis={'50vh'}>
+        <Grid
+          item
+          display={'flex'}
+          flexGrow={1}
+          flexWrap={'wrap'}
+          alignContent={'flex-start'}
+          flexBasis={'50vh'}>
           {sidebar?.visible ? <Sidebar /> : null}
           <Grid item bgcolor={grey['100']} padding={3} height={'100%'} xs paddingX={sidePadding}>
             {backButton && <BackButton text={backButtonText} />}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -41,13 +41,7 @@ export function Layout() {
             }}
           />
         </Grid>
-        <Grid
-          item
-          display={'flex'}
-          flexGrow={1}
-          flexWrap={'wrap'}
-          alignContent={'flex-start'}
-          flexBasis={'50vh'}>
+        <Grid item display={'flex'} flexGrow={1} alignContent={'flex-start'} flexBasis={'50vh'}>
           {sidebar?.visible ? <Sidebar /> : null}
           <Grid item bgcolor={grey['100']} padding={3} height={'100%'} xs paddingX={sidePadding}>
             {backButton && <BackButton text={backButtonText} />}

--- a/src/components/PayeeIcon/PayeeIcon.tsx
+++ b/src/components/PayeeIcon/PayeeIcon.tsx
@@ -1,0 +1,32 @@
+import Box from '@mui/material/Box';
+import React from 'react';
+import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
+import style from 'utils/style';
+
+export interface payeeIconProps {
+  src?: string;
+  alt?: string;
+  visible?: boolean;
+}
+
+export const PayeeIcon = (props: payeeIconProps) => (
+  <Box
+    width={48}
+    height={48}
+    border={`solid 1px ${style.theme.palette.divider}`}
+    borderRadius={6}
+    alignItems="center"
+    display={props.visible ? 'flex' : 'none'}
+    justifyContent="center">
+    {props.src ? (
+      <img
+        src={props.src}
+        alt={props?.alt ? props.alt : 'Logo Ente'}
+        aria-hidden="true"
+        style={{ width: '55%' }}
+      />
+    ) : (
+      <AccountBalanceIcon sx={{ color: style.theme.palette.grey[400] }} />
+    )}
+  </Box>
+);

--- a/src/components/PayeeIcon/index.ts
+++ b/src/components/PayeeIcon/index.ts
@@ -1,0 +1,1 @@
+export { PayeeIcon } from './PayeeIcon';

--- a/src/components/PaymentNotice/Card.test.tsx
+++ b/src/components/PaymentNotice/Card.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useTranslation } from 'react-i18next';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { CardProps } from './Card';
+import { PaymentNotice } from './index';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn()
+}));
+
+jest.mock('components/PayeeIcon', () => ({
+  PayeeIcon: jest.fn(() => <div>Payee Icon</div>)
+}));
+
+describe('Card Component', () => {
+  const renderWithTheme = (ui: React.ReactElement) => {
+    const theme = createTheme();
+    return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+  };
+
+  beforeEach(() => {
+    (useTranslation as jest.Mock).mockReturnValue({
+      t: (key: string) => key
+    });
+  });
+
+  const baseProps: CardProps = {
+    payee: {
+      name: 'Payee Name',
+      srcImg: 'payee.png',
+      altImg: 'Payee Image'
+    },
+    paymentInfo: 'Payment Info',
+    amount: '100',
+    expiringDate: '2022-12-31'
+  };
+
+  it('renders the payee name, payment info, and amount', () => {
+    renderWithTheme(<PaymentNotice.Card {...baseProps} />);
+
+    expect(screen.getByText('Payee Name')).toBeInTheDocument();
+    expect(screen.getByText('Payment Info')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+  });
+
+  it('renders the expiring date if provided', () => {
+    renderWithTheme(<PaymentNotice.Card {...baseProps} />);
+
+    expect(screen.getByText('app.paymentNotice.card.expiring')).toBeInTheDocument();
+    expect(screen.getByText('2022-12-31')).toBeInTheDocument();
+  });
+
+  it('renders the multi-payment message if multiPayment is true', () => {
+    const propsWithMultiPayment: CardProps = {
+      ...baseProps,
+      multiPayment: true
+    };
+    renderWithTheme(<PaymentNotice.Card {...propsWithMultiPayment} />);
+
+    expect(screen.getByText('app.paymentNotice.card.multiPayment')).toBeInTheDocument();
+  });
+
+  it('renders the PayeeIcon', () => {
+    renderWithTheme(<PaymentNotice.Card {...baseProps} />);
+
+    expect(screen.getByText('Payee Icon')).toBeInTheDocument();
+  });
+
+  it('renders the ArrowForwardIosIcon', () => {
+    renderWithTheme(<PaymentNotice.Card {...baseProps} />);
+
+    expect(screen.getByTestId('ArrowForwardIosIcon')).toBeInTheDocument();
+  });
+});

--- a/src/components/PaymentNotice/Card.tsx
+++ b/src/components/PaymentNotice/Card.tsx
@@ -7,6 +7,7 @@ import { PayeeIcon } from 'components/PayeeIcon';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { Theme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
+import { Paper } from '@mui/material';
 
 type InfoProps = { label: string; data: string };
 
@@ -38,47 +39,57 @@ const isMultiPayment = (option: CardPropsOption): option is { multiPayment: bool
 const hasDate = (option: CardPropsOption): option is { expiringDate: string } =>
   'expiringDate' in option && !!option.expiringDate;
 
+/**
+ * This component is considered private and should not be used directly.
+ * Instead, use `PaymentNotice.Card` for rendering the payment notice card.
+ *
+ * @component
+ * @private
+ */
 export const _Card = ({ payee, amount, paymentInfo, ...rest }: CardProps) => {
   const { t } = useTranslation();
   const smUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'));
   return (
-    <Stack
-      borderRadius={1}
-      padding={3}
-      gap={3}
-      direction="row"
-      justifyContent="space-between"
-      sx={{
-        backgroundColor: 'background.paper',
-        boxShadow:
-          '0px 6px 30px 5px #002B551A, 0px 16px 24px 2px #002B550D, 0px 8px 10px -5px #002B551A'
-      }}>
-      <Stack direction="row" alignItems="center" gap={2}>
-        <PayeeIcon src={payee.srcImg} alt={payee.altImg} visible={smUp} />
-        <Stack maxWidth={{ xs: 100, sm: 150, md: 480, lg: 900 }}>
-          <Typography component="div" variant="subtitle1" noWrap>
-            {payee.name}
-          </Typography>
-          <Typography>{paymentInfo}</Typography>
+    <Paper elevation={16}>
+      <Stack
+        component="section"
+        borderRadius={1}
+        padding={3}
+        gap={3}
+        direction="row"
+        height="152px"
+        justifyContent="space-between">
+        <Stack direction="row" alignItems="center" gap={2} component="header">
+          <PayeeIcon src={payee.srcImg} alt={payee.altImg} visible={smUp} />
+          <Stack maxWidth={{ xs: 110, sm: 150, md: 480, lg: 460, xl: 600 }}>
+            <Typography component="h2" variant="subtitle1" noWrap>
+              {payee.name}
+            </Typography>
+            <Typography component="p">{paymentInfo}</Typography>
+          </Stack>
+        </Stack>
+        <Stack direction="row" gap={2} alignItems="center" component="div">
+          <Divider orientation="vertical" flexItem variant="fullWidth" />
+          <Stack width="12rem" component="aside">
+            <Info label={t('app.paymentNotice.card.amount')} data={amount} />
+            {isMultiPayment(rest) && (
+              <Stack
+                borderRadius="4px"
+                alignItems="center"
+                sx={{ backgroundColor: '#E1F5FE' }}
+                component="div">
+                <Typography padding="3px" variant="subtitle2" lineHeight="18px">
+                  {t('app.paymentNotice.card.multiPayment')}
+                </Typography>
+              </Stack>
+            )}
+            {hasDate(rest) && (
+              <Info label={t('app.paymentNotice.card.expiring')} data={rest.expiringDate} />
+            )}
+          </Stack>
+          <ArrowForwardIosIcon color="primary" fontSize="small" />
         </Stack>
       </Stack>
-      <Stack direction="row" gap={2} alignItems="center">
-        <Divider orientation="vertical" flexItem variant="fullWidth" />
-        <Stack width="12rem">
-          <Info label={t('app.paymentNotice.card.amount')} data={amount} />
-          {isMultiPayment(rest) && (
-            <Stack borderRadius="4px" alignItems="center" sx={{ backgroundColor: '#E1F5FE' }}>
-              <Typography padding="3px" variant="subtitle2" lineHeight="18px">
-                {t('app.paymentNotice.card.multiPayment')}
-              </Typography>
-            </Stack>
-          )}
-          {hasDate(rest) && (
-            <Info label={t('app.paymentNotice.card.expiring')} data={rest.expiringDate} />
-          )}
-        </Stack>
-        <ArrowForwardIosIcon color="primary" fontSize="small" />
-      </Stack>
-    </Stack>
+    </Paper>
   );
 };

--- a/src/components/PaymentNotice/Card.tsx
+++ b/src/components/PaymentNotice/Card.tsx
@@ -1,0 +1,84 @@
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import Divider from '@mui/material/Divider';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+import { PayeeIcon } from 'components/PayeeIcon';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Theme } from '@mui/material/styles';
+import { useTranslation } from 'react-i18next';
+
+type InfoProps = { label: string; data: string };
+
+const Info = (props: InfoProps) => (
+  <Stack>
+    <Typography component="div" variant="body2">
+      {props.label}
+    </Typography>
+    <Typography component="div" variant="subtitle1">
+      {props.data}
+    </Typography>
+  </Stack>
+);
+
+type CardPropsOption = { expiringDate: string } | { multiPayment: boolean };
+export type CardProps = {
+  payee: {
+    name: string;
+    srcImg?: string;
+    altImg?: string;
+  };
+  paymentInfo: string;
+  amount: string;
+} & CardPropsOption;
+
+const isMultiPayment = (option: CardPropsOption): option is { multiPayment: boolean } =>
+  'multiPayment' in option && option.multiPayment === true;
+
+const hasDate = (option: CardPropsOption): option is { expiringDate: string } =>
+  'expiringDate' in option && !!option.expiringDate;
+
+export const _Card = ({ payee, amount, paymentInfo, ...rest }: CardProps) => {
+  const { t } = useTranslation();
+  const smUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'));
+  return (
+    <Stack
+      borderRadius={1}
+      padding={3}
+      gap={3}
+      direction="row"
+      justifyContent="space-between"
+      sx={{
+        backgroundColor: 'background.paper',
+        boxShadow:
+          '0px 6px 30px 5px #002B551A, 0px 16px 24px 2px #002B550D, 0px 8px 10px -5px #002B551A'
+      }}>
+      <Stack direction="row" alignItems="center" gap={2}>
+        <PayeeIcon src={payee.srcImg} alt={payee.altImg} visible={smUp} />
+        <Stack maxWidth={{ xs: 100, sm: 150, md: 480, lg: 900 }}>
+          <Typography component="div" variant="subtitle1" noWrap>
+            {payee.name}
+          </Typography>
+          <Typography>{paymentInfo}</Typography>
+        </Stack>
+      </Stack>
+      <Stack direction="row" gap={2} alignItems="center">
+        <Divider orientation="vertical" flexItem variant="fullWidth" />
+        <Stack width="12rem">
+          <Info label={t('app.paymentNotice.card.amount')} data={amount} />
+          {isMultiPayment(rest) && (
+            <Stack borderRadius="4px" alignItems="center" sx={{ backgroundColor: '#E1F5FE' }}>
+              <Typography padding="3px" variant="subtitle2" lineHeight="18px">
+                {t('app.paymentNotice.card.multiPayment')}
+              </Typography>
+            </Stack>
+          )}
+          {hasDate(rest) && (
+            <Info label={t('app.paymentNotice.card.expiring')} data={rest.expiringDate} />
+          )}
+        </Stack>
+        <ArrowForwardIosIcon color="primary" fontSize="small" />
+      </Stack>
+    </Stack>
+  );
+};

--- a/src/components/PaymentNotice/PaymentNotice.tsx
+++ b/src/components/PaymentNotice/PaymentNotice.tsx
@@ -1,4 +1,6 @@
+import { _Card } from './Card';
 import { _Preview } from './Preview';
 
 export const PaymentNotice = () => {};
 PaymentNotice.Preview = _Preview;
+PaymentNotice.Card = _Card;

--- a/src/components/PaymentNotice/PaymentNotice.tsx
+++ b/src/components/PaymentNotice/PaymentNotice.tsx
@@ -1,6 +1,25 @@
-import { _Card } from './Card';
 import { _Preview } from './Preview';
+import { _Card } from './Card';
 
+/**
+ * PaymentNotice is the main component for handling payment notices.
+ * It includes sub-components for displaying payment notice elements.
+ *
+ * Example: <PaymentNotice.Preview/>
+ * @component
+ */
 export const PaymentNotice = () => {};
+
+/**
+ * Preview component for PaymentNotice.
+ * Use <PaymentNotice.Preview /> instead of direct use.
+ * @type {React.ComponentType}
+ */
 PaymentNotice.Preview = _Preview;
+
+/**
+ * Card component for PaymentNotice.
+ * Use <PaymentNotice.Card /> instead of direct use.
+ * @type {React.ComponentType}
+ */
 PaymentNotice.Card = _Card;

--- a/src/components/PaymentNotice/Preview.tsx
+++ b/src/components/PaymentNotice/Preview.tsx
@@ -5,6 +5,13 @@ import { IllusSharingInfo } from '@pagopa/mui-italia';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+/**
+ * This component is considered private and should not be used directly.
+ * Instead, use `PaymentNotice.Preview` for rendering the payment notice preview.
+ *
+ * @component
+ * @private
+ */
 export const _Preview = () => {
   const { t } = useTranslation();
   const mdUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));

--- a/src/components/Transactions/Transaction.tsx
+++ b/src/components/Transactions/Transaction.tsx
@@ -1,15 +1,14 @@
-import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import React from 'react';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
-import style from 'utils/style';
 import { Box, Chip, ChipOwnProps, Stack, Typography, useMediaQuery } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useNavigate } from 'react-router-dom';
 import { theme } from '@pagopa/mui-italia';
 import { ArcRoutes } from 'routes/routes';
 import utils from 'utils';
+import { PayeeIcon } from 'components/PayeeIcon';
 
 export interface TransactionProps {
   payee: {
@@ -26,38 +25,10 @@ export interface TransactionProps {
   id: string;
 }
 
-interface payeeIconProps {
-  src?: string;
-  alt?: string;
-  visible?: boolean;
-}
-
 const StyledTableCell = styled(TableCell)(({ theme }) => ({
   borderBottomColor: theme.palette.divider,
   cursor: 'pointer'
 }));
-
-const PayeeIcon = (props: payeeIconProps) => (
-  <Box
-    width={48}
-    height={48}
-    border={`solid 1px ${style.theme.palette.divider}`}
-    borderRadius={6}
-    alignItems="center"
-    display={props.visible ? 'flex' : 'none'}
-    justifyContent="center">
-    {props.src ? (
-      <img
-        src={props.src}
-        alt={props?.alt ? props.alt : 'Logo Ente'}
-        aria-hidden="true"
-        style={{ width: '55%' }}
-      />
-    ) : (
-      <AccountBalanceIcon sx={{ color: style.theme.palette.grey[400] }} />
-    )}
-  </Box>
-);
 
 const Transaction = (props: TransactionProps) => {
   const navigate = useNavigate();

--- a/src/routes/PaymentNotices.tsx
+++ b/src/routes/PaymentNotices.tsx
@@ -42,6 +42,8 @@ const paymentNoticesMock: CardProps[] = [
   }
 ];
 
+const updatedDate = new Date();
+
 export const PaymentNotices = () => {
   const { t } = useTranslation();
 
@@ -58,7 +60,12 @@ export const PaymentNotices = () => {
             </Typography>
             <Typography display="flex" variant="body1" flexDirection="row" gap="5px">
               <Typography color="text.secondary">{t('app.paymentNotices.updated')}</Typography>
-              <Typography sx={{ fontWeight: 600 }}>14 giugno 2020, 15:50</Typography>
+              <Typography sx={{ fontWeight: 600 }}>
+                {updatedDate.toLocaleString(navigator.language, {
+                  timeStyle: 'short',
+                  dateStyle: 'medium'
+                })}
+              </Typography>
             </Typography>
           </Stack>
           <Stack gap={3}>

--- a/src/routes/PaymentNotices.tsx
+++ b/src/routes/PaymentNotices.tsx
@@ -1,0 +1,81 @@
+import { ErrorOutline } from '@mui/icons-material';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { ButtonNaked } from '@pagopa/mui-italia';
+import { PaymentNotice } from 'components/PaymentNotice';
+import { CardProps } from 'components/PaymentNotice/Card';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const paymentNoticesMock: CardProps[] = [
+  {
+    payee: {
+      name: 'Politecnico di Milano'
+    },
+    paymentInfo: 'RATA 1 - Anno Accademico 2023/2024',
+    amount: '171,00 €',
+    expiringDate: '31/01/2099'
+  },
+  {
+    payee: {
+      name: 'Comune di Milano'
+    },
+    paymentInfo: 'TARI 2024',
+    amount: '171,00 €',
+    multiPayment: true
+  },
+  {
+    payee: {
+      name: 'Comune di Milano'
+    },
+    paymentInfo: 'Violazione CDS Verbale 0123456',
+    amount: '28,70 €',
+    multiPayment: true
+  },
+  {
+    payee: {
+      name: 'Istituto d’Istruzione Superiore con un nome Molto Lungo che può andare su più righe'
+    },
+    paymentInfo: 'Iscrizione Anno Accademico 2023/2024',
+    amount: '171,00 €',
+    expiringDate: '31/01/2099'
+  }
+];
+
+export const PaymentNotices = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Stack height="100%" justifyContent="space-between">
+      <Stack gap={5}>
+        <Typography paddingTop={3} variant="h4">
+          {t('app.paymentNotices.title')}
+        </Typography>
+        <Stack gap={3}>
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Typography variant="h6">
+              {t('app.paymentNotices.found')} 12 {t('app.paymentNotices.notice')}
+            </Typography>
+            <Typography display="flex" variant="body1" flexDirection="row" gap="5px">
+              <Typography color="text.secondary">{t('app.paymentNotices.updated')}</Typography>
+              <Typography sx={{ fontWeight: 600 }}>14 giugno 2020, 15:50</Typography>
+            </Typography>
+          </Stack>
+          <Stack gap={3}>
+            {paymentNoticesMock.map((paymentNotice) => (
+              <PaymentNotice.Card {...paymentNotice} />
+            ))}
+          </Stack>
+        </Stack>
+      </Stack>
+      <Stack padding={1.3} gap={1} justifyContent="flex-start">
+        <Typography variant="body1">{t('app.paymentNotices.alert.info')}</Typography>
+        <Typography color="error">
+          <ButtonNaked variant="text" size="medium" color="inherit" startIcon={<ErrorOutline />}>
+            {t('app.paymentNotices.alert.action')}
+          </ButtonNaked>
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+};

--- a/src/routes/PaymentNotices.tsx
+++ b/src/routes/PaymentNotices.tsx
@@ -46,7 +46,7 @@ export const PaymentNotices = () => {
   const { t } = useTranslation();
 
   return (
-    <Stack height="100%" justifyContent="space-between">
+    <Stack height="100%" justifyContent={{ lg: 'space-between' }}>
       <Stack gap={5}>
         <Typography paddingTop={3} variant="h4">
           {t('app.paymentNotices.title')}
@@ -68,7 +68,7 @@ export const PaymentNotices = () => {
           </Stack>
         </Stack>
       </Stack>
-      <Stack padding={1.3} gap={1} justifyContent="flex-start">
+      <Stack padding={1.3} gap={1} justifyContent="flex-start" marginTop={{ xs: 10, lg: 0 }}>
         <Typography variant="body1">{t('app.paymentNotices.alert.info')}</Typography>
         <Typography color="error">
           <ButtonNaked variant="text" size="medium" color="inherit" startIcon={<ErrorOutline />}>

--- a/src/routes/PaymentNotices.tsx
+++ b/src/routes/PaymentNotices.tsx
@@ -7,11 +7,12 @@ import { CardProps } from 'components/PaymentNotice/Card';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-const paymentNoticesMock: CardProps[] = [
+const paymentNoticesMock: Array<CardProps & { id: number }> = [
   {
     payee: {
       name: 'Politecnico di Milano'
     },
+    id: 1,
     paymentInfo: 'RATA 1 - Anno Accademico 2023/2024',
     amount: '171,00 €',
     expiringDate: '31/01/2099'
@@ -20,6 +21,7 @@ const paymentNoticesMock: CardProps[] = [
     payee: {
       name: 'Comune di Milano'
     },
+    id: 2,
     paymentInfo: 'TARI 2024',
     amount: '171,00 €',
     multiPayment: true
@@ -28,6 +30,7 @@ const paymentNoticesMock: CardProps[] = [
     payee: {
       name: 'Comune di Milano'
     },
+    id: 3,
     paymentInfo: 'Violazione CDS Verbale 0123456',
     amount: '28,70 €',
     multiPayment: true
@@ -36,6 +39,7 @@ const paymentNoticesMock: CardProps[] = [
     payee: {
       name: 'Istituto d’Istruzione Superiore con un nome Molto Lungo che può andare su più righe'
     },
+    id: 4,
     paymentInfo: 'Iscrizione Anno Accademico 2023/2024',
     amount: '171,00 €',
     expiringDate: '31/01/2099'
@@ -48,19 +52,33 @@ export const PaymentNotices = () => {
   const { t } = useTranslation();
 
   return (
-    <Stack height="100%" justifyContent={{ lg: 'space-between' }}>
-      <Stack gap={5}>
-        <Typography paddingTop={3} variant="h4">
+    <Stack height="100%" justifyContent={{ lg: 'space-between' }} component="main">
+      <Stack gap={5} component="section">
+        <Typography paddingTop={3} variant="h4" component="h1">
           {t('app.paymentNotices.title')}
         </Typography>
         <Stack gap={3}>
-          <Stack direction="row" justifyContent="space-between" alignItems="center">
-            <Typography variant="h6">
-              {t('app.paymentNotices.found')} 12 {t('app.paymentNotices.notice')}
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            alignItems="center"
+            component="header">
+            <Typography variant="h6" component="h2">
+              {`${t('app.paymentNotices.found')} ${paymentNoticesMock.length} ${t('app.paymentNotices.notice')}`}
             </Typography>
-            <Typography display="flex" variant="body1" flexDirection="row" gap="5px">
-              <Typography color="text.secondary">{t('app.paymentNotices.updated')}</Typography>
-              <Typography sx={{ fontWeight: 600 }}>
+            <Typography
+              display="flex"
+              variant="body1"
+              component="div"
+              flexDirection="row"
+              gap="5px">
+              <Typography color="text.secondary" component="span">
+                {t('app.paymentNotices.updated')}
+              </Typography>
+              <Typography
+                sx={{ fontWeight: 600 }}
+                component="time"
+                dateTime={updatedDate.toISOString()}>
                 {updatedDate.toLocaleString(navigator.language, {
                   timeStyle: 'short',
                   dateStyle: 'medium'
@@ -68,17 +86,29 @@ export const PaymentNotices = () => {
               </Typography>
             </Typography>
           </Stack>
-          <Stack gap={3}>
+          <Stack gap={3} component="section">
             {paymentNoticesMock.map((paymentNotice) => (
-              <PaymentNotice.Card {...paymentNotice} />
+              <PaymentNotice.Card key={paymentNotice.id} {...paymentNotice} />
             ))}
           </Stack>
         </Stack>
       </Stack>
-      <Stack padding={1.3} gap={1} justifyContent="flex-start" marginTop={{ xs: 10, lg: 0 }}>
-        <Typography variant="body1">{t('app.paymentNotices.alert.info')}</Typography>
-        <Typography color="error">
-          <ButtonNaked variant="text" size="medium" color="inherit" startIcon={<ErrorOutline />}>
+      <Stack
+        padding={1.3}
+        gap={1}
+        justifyContent="flex-start"
+        marginTop={{ xs: 10, lg: 0 }}
+        component="aside">
+        <Typography variant="body1" component="p">
+          {t('app.paymentNotices.alert.info')}
+        </Typography>
+        <Typography color="error" component="div">
+          <ButtonNaked
+            variant="text"
+            size="medium"
+            color="inherit"
+            startIcon={<ErrorOutline />}
+            aria-label={t('app.paymentNotices.alert.action')}>
             {t('app.paymentNotices.alert.action')}
           </ButtonNaked>
         </Typography>

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -2,6 +2,7 @@ export enum ArcRoutes {
   DASHBOARD = '/',
   TRANSACTION = '/transactions/:id',
   TRANSACTIONS = '/transactions/',
+  PAYMENT_NOTICES = '/payment-notices/',
   USER = '/user',
   COURTESY_PAGE = '/courtesy',
   LOGIN = '/login',

--- a/src/stories/PaymentNotice.stories.tsx
+++ b/src/stories/PaymentNotice.stories.tsx
@@ -15,8 +15,33 @@ const meta: Meta<typeof PaymentNotice.Preview> = {
 };
 
 export default meta;
-type StoryTabs = StoryObj<typeof PaymentNotice.Preview>;
+type StoryPreview = StoryObj<typeof PaymentNotice.Preview>;
+type StoryCard = StoryObj<typeof PaymentNotice.Card>;
 
-export const Preview: StoryTabs = {
+export const Preview: StoryPreview = {
   render: PaymentNotice.Preview
+};
+
+export const CardSinglePayment: StoryCard = {
+  render: PaymentNotice.Card,
+  args: {
+    payee: {
+      name: 'Politecnico di Milano'
+    },
+    paymentInfo: 'RATA 1 - Anno Accademico 2023/2024',
+    amount: '171,00 €',
+    expiringDate: '31/01/2099'
+  }
+};
+
+export const CardMultiPayment: StoryCard = {
+  render: PaymentNotice.Card,
+  args: {
+    payee: {
+      name: 'Politecnico di Milano'
+    },
+    paymentInfo: 'RATA 1 - Anno Accademico 2023/2024',
+    amount: '171,00 €',
+    multiPayment: true
+  }
 };

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -72,6 +72,21 @@
         "title": "Cerca i tuoi avvisi di pagamento pagoPA",
         "description": "Qui puoi trovare gli avvisi da pagare a tuo nome predisposti dagli enti aderenti al servizio",
         "action": "Cerca i tuoi avvisi"
+      },
+      "card": {
+        "amount": "Importo",
+        "multiPayment": "Altre opzioni di pagamento",
+        "expiring": "Rata unica entro il"
+      }
+    },
+    "paymentNotices": {
+      "title": "I tuoi avvisi di pagamento",
+      "found": "Abbiamo trovato",
+      "notice": "avvisi",
+      "updated": "Aggiornato il",
+      "alert": {
+        "info": "Gli avvisi sono stati recuperati dagli archivi degli enti creditori aderenti al servizio.",
+        "action": "Segnala un problema"
       }
     },
     "routes": {

--- a/src/utils/style.tsx
+++ b/src/utils/style.tsx
@@ -18,9 +18,9 @@ const customTheme = createTheme({
   components: {
     MuiTab: {
       styleOverrides: {
-        root: {
+        root: ({ theme }) => ({
           borderBottom: `solid 2px ${theme.palette.grey[300]}`
-        }
+        })
       }
     },
     MuiChip: {
@@ -34,9 +34,9 @@ const customTheme = createTheme({
     },
     MuiButton: {
       styleOverrides: {
-        sizeLarge: {
+        sizeLarge: ({ theme }) => ({
           minHeight: theme.spacing(6)
-        }
+        })
       }
     }
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Adds PaymentNotice.Card component
- Adds PaymentNotices component
- Adds PaymentNotices to routing
- PaymentNotice.Card stories
- Reafctored PayeeIcon as a separate component
- i18n for PaymentNotices and PaymentNotice.Card
- unit tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Adds a route showing all the user payment notice. All data rendered in this pr is static.

#### How Has This Been Tested?
- Visual testing
- Unit tests
- Storybook stories
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
![image](https://github.com/pagopa/pagopa-arc-fe/assets/61319404/e4bc7486-b584-4fbb-aaa8-2053c5e03c64)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
