### PR TITLE
feat: [P4PU-212] payment notices page skeleton and  fake loading time

### DIFF
--- a/src/components/PaymentNotice/Info.test.tsx
+++ b/src/components/PaymentNotice/Info.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { PaymentNotice } from './PaymentNotice';
+
+describe('Payment notices info component', () => {
+  it('should render as expected', () => {
+    render(<PaymentNotice.Info />);
+  });
+});

--- a/src/components/PaymentNotice/Info.tsx
+++ b/src/components/PaymentNotice/Info.tsx
@@ -1,0 +1,30 @@
+import { ErrorOutline } from '@mui/icons-material';
+import { Stack, Typography } from '@mui/material';
+import { ButtonNaked } from '@pagopa/mui-italia';
+import { useTranslation } from 'react-i18next';
+
+export const _Info = () => {
+  const { t } = useTranslation();
+  return (
+    <Stack
+      padding={1.3}
+      gap={1}
+      justifyContent="flex-start"
+      marginTop={{ xs: 10, lg: 0 }}
+      component="aside">
+      <Typography variant="body1" component="p">
+        {t('app.paymentNotices.alert.info')}
+      </Typography>
+      <Typography color="error" component="div">
+        <ButtonNaked
+          variant="text"
+          size="medium"
+          color="inherit"
+          startIcon={<ErrorOutline />}
+          aria-label={t('app.paymentNotices.alert.action')}>
+          {t('app.paymentNotices.alert.action')}
+        </ButtonNaked>
+      </Typography>
+    </Stack>
+  );
+};

--- a/src/components/PaymentNotice/Info.tsx
+++ b/src/components/PaymentNotice/Info.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ErrorOutline } from '@mui/icons-material';
 import { Stack, Typography } from '@mui/material';
 import { ButtonNaked } from '@pagopa/mui-italia';

--- a/src/components/PaymentNotice/PaymentNotice.tsx
+++ b/src/components/PaymentNotice/PaymentNotice.tsx
@@ -4,6 +4,7 @@ import { _Detail } from './Detail';
 import { _Empty } from './Empty';
 import { _Error } from './Error';
 import { _List } from './List';
+import { _Info } from './Info';
 
 /**
  * PaymentNotice is the main component for handling payment notices.
@@ -54,3 +55,9 @@ PaymentNotice.Detail = _Detail;
  * @type {React.ComponentType}
  */
 PaymentNotice.List = _List;
+
+/* * Info  component for PaymentNotice list.
+ * Use <PaymentNotice.Info /> instead of direct use.
+ * @type {React.ComponentType}
+ */
+PaymentNotice.Info = _Info;

--- a/src/components/QueryLoader/index.tsx
+++ b/src/components/QueryLoader/index.tsx
@@ -5,19 +5,16 @@ import { useIsFetching } from '@tanstack/react-query';
 interface QueryLoaderProps {
   queryKey: string;
   children: React.ReactNode;
-  fallback?: React.ReactNode;
   loaderComponent?: React.ReactNode;
 }
 
 /**
  * This simple component receive a queryKey identifier as prop and renders a loading spinner
  * until the relative fetch is in progress, otherwise it renders the children
- * fallback can be used when something goes wrong with the fetch
  */
-const QueryLoader = ({ loaderComponent, queryKey, children, fallback }: QueryLoaderProps) => {
+const QueryLoader = ({ loaderComponent, queryKey, children }: QueryLoaderProps) => {
   const loader = loaderComponent || <CircularProgress />;
   const isFetching = useIsFetching({ queryKey: [queryKey] });
-  if (fallback && !isFetching) return fallback;
   return <>{isFetching ? loader : children}</>;
 };
 

--- a/src/components/QueryLoader/index.tsx
+++ b/src/components/QueryLoader/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { CircularProgress } from '@mui/material';
 import { useIsFetching } from '@tanstack/react-query';
 
@@ -6,16 +6,28 @@ interface QueryLoaderProps {
   queryKey: string;
   children: React.ReactNode;
   loaderComponent?: React.ReactNode;
+  /** minimum loading time in millis. useful for fake loading time or to avoid flickering  */
+  atLeast?: number;
 }
 
 /**
  * This simple component receive a queryKey identifier as prop and renders a loading spinner
  * until the relative fetch is in progress, otherwise it renders the children
  */
-const QueryLoader = ({ loaderComponent, queryKey, children }: QueryLoaderProps) => {
-  const loader = loaderComponent || <CircularProgress />;
+const QueryLoader = (props: QueryLoaderProps) => {
+  const { queryKey, loaderComponent, children } = props;
+  const [atLeast, setLeast] = useState(0);
   const isFetching = useIsFetching({ queryKey: [queryKey] });
-  return <>{isFetching ? loader : children}</>;
+
+  useEffect(() => {
+    if (props.atLeast && isFetching) {
+      setLeast(props.atLeast);
+      setTimeout(() => setLeast(0), props.atLeast);
+    }
+  }, [isFetching, props.atLeast]);
+
+  const loader = loaderComponent || <CircularProgress />;
+  return <>{isFetching + atLeast ? loader : children}</>;
 };
 
 export default QueryLoader;

--- a/src/components/QueryLoader/queryLoader.test.tsx
+++ b/src/components/QueryLoader/queryLoader.test.tsx
@@ -5,9 +5,9 @@ import QueryLoader from '.';
 import { QueryFilters } from '@tanstack/react-query';
 import { CircularProgress } from '@mui/material';
 
-const mockeduseIsFetching = jest.fn();
+const mockedUseIsFetching = jest.fn();
 jest.mock('@tanstack/react-query', () => ({
-  useIsFetching: (filters?: QueryFilters) => mockeduseIsFetching(filters)
+  useIsFetching: (filters?: QueryFilters) => mockedUseIsFetching(filters)
 }));
 
 jest.mock('@mui/material', () => ({
@@ -16,40 +16,52 @@ jest.mock('@mui/material', () => ({
 
 describe('Query Loader component', () => {
   it('should not render the children when fetching', () => {
-    mockeduseIsFetching.mockReturnValueOnce(true);
+    mockedUseIsFetching.mockReturnValue(1);
     render(
       <QueryLoader queryKey="testQueryKey" loaderComponent={<p>test loader</p>}>
         <p>test children</p>
       </QueryLoader>
     );
-    expect(mockeduseIsFetching).toHaveBeenCalledTimes(1);
-    expect(mockeduseIsFetching).toHaveBeenCalledWith({ queryKey: ['testQueryKey'] });
+    expect(mockedUseIsFetching).toHaveBeenCalledTimes(1);
+    expect(mockedUseIsFetching).toHaveBeenCalledWith({ queryKey: ['testQueryKey'] });
     expect(CircularProgress).not.toHaveBeenCalled();
     expect(screen.getByText('test loader')).toBeInTheDocument();
     expect(screen.queryByText('test children')).toBeNull();
   });
 
   it('should render the children when not fetching', () => {
-    mockeduseIsFetching.mockReturnValueOnce(false);
+    mockedUseIsFetching.mockReturnValue(0);
     render(
       <QueryLoader queryKey="testQueryKey" loaderComponent={<p>test loader</p>}>
         <p>test children</p>
       </QueryLoader>
     );
-    expect(mockeduseIsFetching).toHaveBeenCalledTimes(1);
-    expect(mockeduseIsFetching).toHaveBeenCalledWith({ queryKey: ['testQueryKey'] });
+    expect(mockedUseIsFetching).toHaveBeenCalledTimes(1);
     expect(screen.queryByText('test loader')).toBeNull();
     expect(screen.getByText('test children')).toBeInTheDocument();
   });
 
   it('should render the default loader component', () => {
-    mockeduseIsFetching.mockReturnValueOnce(true);
+    mockedUseIsFetching.mockReturnValue(1);
     render(
       <QueryLoader queryKey="testQueryKey">
         <p>test children</p>
       </QueryLoader>
     );
-    expect(mockeduseIsFetching).toHaveBeenCalledTimes(1);
+    expect(mockedUseIsFetching).toHaveBeenCalledTimes(1);
     expect(CircularProgress).toHaveBeenCalled();
+  });
+
+  it('should not render children because a minum delay (5000) is provided', () => {
+    mockedUseIsFetching.mockReturnValue(1);
+    render(
+      <QueryLoader queryKey="testQueryKey" atLeast={5000}>
+        <p>test children</p>
+      </QueryLoader>
+    );
+    expect(mockedUseIsFetching).toHaveBeenCalled();
+    expect(mockedUseIsFetching).toHaveBeenCalledWith({ queryKey: ['testQueryKey'] });
+    expect(CircularProgress).toHaveBeenCalled();
+    expect(screen.queryByText('test children')).toBeNull();
   });
 });

--- a/src/components/QueryLoader/queryLoader.test.tsx
+++ b/src/components/QueryLoader/queryLoader.test.tsx
@@ -42,17 +42,6 @@ describe('Query Loader component', () => {
     expect(screen.getByText('test children')).toBeInTheDocument();
   });
 
-  it('should render the fallback component', () => {
-    render(
-      <QueryLoader queryKey="testQueryKey" fallback={<p>test fallback</p>}>
-        <p>test children</p>
-      </QueryLoader>
-    );
-    expect(mockeduseIsFetching).toHaveBeenCalledTimes(1);
-    expect(screen.queryByText('test children')).toBeNull();
-    expect(screen.getByText('test fallback')).toBeInTheDocument();
-  });
-
   it('should render the default loader component', () => {
     mockeduseIsFetching.mockReturnValueOnce(true);
     render(

--- a/src/components/Skeleton/PaymentNoticesList.tsx
+++ b/src/components/Skeleton/PaymentNoticesList.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Card, CardContent, LinearProgress, Skeleton, Stack, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+const PaymentNoticesList = () => {
+  const { t } = useTranslation();
+  return (
+    <Stack spacing={3}>
+      <Card>
+        <CardContent sx={{ padding: 3 }}>
+          <Typography variant="body1" mb={3} textAlign="center">
+            {t('app.paymentNotices.loading')}
+          </Typography>
+          <LinearProgress />
+        </CardContent>
+      </Card>
+
+      {Array.from({ length: 4 }, (_, i) => (
+        <Card key={i}>
+          <CardContent sx={{ padding: 3 }}>
+            <Skeleton variant="rounded" height={60} />
+          </CardContent>
+        </Card>
+      ))}
+    </Stack>
+  );
+};
+
+export default PaymentNoticesList;

--- a/src/components/Skeleton/index.ts
+++ b/src/components/Skeleton/index.ts
@@ -1,4 +1,5 @@
 import TransactionListSkeleton from './TransactionsList';
 import TransactionDetailsSkeleton from './TransactionDetails';
+import PaymentNoticesList from './PaymentNoticesList';
 
-export { TransactionListSkeleton, TransactionDetailsSkeleton };
+export { TransactionListSkeleton, TransactionDetailsSkeleton, PaymentNoticesList };

--- a/src/components/Skeleton/index.ts
+++ b/src/components/Skeleton/index.ts
@@ -1,5 +1,5 @@
 import TransactionListSkeleton from './TransactionsList';
 import TransactionDetailsSkeleton from './TransactionDetails';
-import PaymentNoticesList from './PaymentNoticesList';
+import PaymentNoticesListSkeleton from './PaymentNoticesList';
 
-export { TransactionListSkeleton, TransactionDetailsSkeleton, PaymentNoticesList };
+export { TransactionListSkeleton, TransactionDetailsSkeleton, PaymentNoticesListSkeleton };

--- a/src/components/Skeleton/skeleton.test.tsx
+++ b/src/components/Skeleton/skeleton.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { TransactionListSkeleton, TransactionDetailsSkeleton } from './';
+import { TransactionListSkeleton, TransactionDetailsSkeleton, PaymentNoticesListSkeleton } from '.';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 jest.mock('@mui/material/useMediaQuery', () => jest.fn());
@@ -15,5 +15,12 @@ describe('TransactionDetailsSkeleton component', () => {
   it('should render as expected', () => {
     (useMediaQuery as jest.Mock).mockReturnValue(true);
     render(<TransactionDetailsSkeleton />);
+  });
+});
+
+describe('PaymentNoticesListSkeleton component', () => {
+  it('should render as expected', () => {
+    (useMediaQuery as jest.Mock).mockReturnValue(true);
+    render(<PaymentNoticesListSkeleton />);
   });
 });

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -63,11 +63,12 @@ const Dashboard = () => {
         padding={{ xs: 3, md: 2 }}
         margin={{ xs: -3, md: 0 }}
         marginTop={0}>
-        <QueryLoader
-          queryKey="transactions"
-          loaderComponent={<TransactionListSkeleton />}
-          fallback={isError && <Retry action={refetch} />}>
-          {rows && rows.length > 0 ? <TransactionsList rows={rows} /> : <Empty />}
+        <QueryLoader queryKey="transactions" loaderComponent={<TransactionListSkeleton />}>
+          {(() => {
+            if (isError || !rows) return <Retry action={refetch} />;
+            if (rows.length === 0) return <Empty />;
+            return <TransactionsList rows={rows} />;
+          })()}
         </QueryLoader>
       </Box>
     </>

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -27,6 +27,12 @@ const Dashboard = () => {
       action: (id) => navigate(`${ArcRoutes.TRANSACTION}`.replace(':ID', id))
     });
 
+  const Content = () => {
+    if (isError || !rows) return <Retry action={refetch} />;
+    if (rows.length === 0) return <Empty />;
+    return <TransactionsList rows={rows} />;
+  };
+
   return (
     <>
       <Stack
@@ -64,11 +70,7 @@ const Dashboard = () => {
         margin={{ xs: -3, md: 0 }}
         marginTop={0}>
         <QueryLoader queryKey="transactions" loaderComponent={<TransactionListSkeleton />}>
-          {(() => {
-            if (isError || !rows) return <Retry action={refetch} />;
-            if (rows.length === 0) return <Empty />;
-            return <TransactionsList rows={rows} />;
-          })()}
+          <Content />
         </QueryLoader>
       </Box>
     </>

--- a/src/routes/PaymentNotices.tsx
+++ b/src/routes/PaymentNotices.tsx
@@ -2,7 +2,7 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { PaymentNotice } from 'components/PaymentNotice';
 import QueryLoader from 'components/QueryLoader';
-import { PaymentNoticesList } from 'components/Skeleton';
+import { PaymentNoticesListSkeleton } from 'components/Skeleton';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import utils from 'utils';
@@ -19,20 +19,18 @@ export const PaymentNotices = () => {
       <Stack height="100%" justifyContent={{ lg: 'space-between' }} component="main">
         <QueryLoader
           queryKey="paymentNotices"
-          loaderComponent={<PaymentNoticesList />}
+          loaderComponent={<PaymentNoticesListSkeleton />}
           atLeast={5000}>
-          <Stack gap={5} component="section">
-            {(() => {
-              if (isError || !data) return <PaymentNotice.Error />;
-              if (!data.length) return <PaymentNotice.Empty />;
-              return (
-                <>
-                  <PaymentNotice.List paymentNoticesList={data} />
-                  <PaymentNotice.Info />
-                </>
-              );
-            })()}
-          </Stack>
+          {(() => {
+            if (isError || !data) return <PaymentNotice.Error />;
+            if (!data.length) return <PaymentNotice.Empty />;
+            return (
+              <Stack gap={5} component="section">
+                <PaymentNotice.List paymentNoticesList={data} />
+                <PaymentNotice.Info />
+              </Stack>
+            );
+          })()}
         </QueryLoader>
       </Stack>
     </>

--- a/src/routes/PaymentNotices.tsx
+++ b/src/routes/PaymentNotices.tsx
@@ -11,6 +11,17 @@ export const PaymentNotices = () => {
   const { t } = useTranslation();
   const { data, isError } = utils.loaders.getPaymentNotices();
 
+  const Content = () => {
+    if (isError || !data) return <PaymentNotice.Error />;
+    if (!data.length) return <PaymentNotice.Empty />;
+    return (
+      <Stack gap={5} component="section">
+        <PaymentNotice.List paymentNoticesList={data} />
+        <PaymentNotice.Info />
+      </Stack>
+    );
+  };
+
   return (
     <>
       <Typography mb={3} variant="h3" component="h1">
@@ -21,16 +32,7 @@ export const PaymentNotices = () => {
           queryKey="paymentNotices"
           loaderComponent={<PaymentNoticesListSkeleton />}
           atLeast={5000}>
-          {(() => {
-            if (isError || !data) return <PaymentNotice.Error />;
-            if (!data.length) return <PaymentNotice.Empty />;
-            return (
-              <Stack gap={5} component="section">
-                <PaymentNotice.List paymentNoticesList={data} />
-                <PaymentNotice.Info />
-              </Stack>
-            );
-          })()}
+          <Content />
         </QueryLoader>
       </Stack>
     </>

--- a/src/routes/PaymentNotices.tsx
+++ b/src/routes/PaymentNotices.tsx
@@ -11,8 +11,6 @@ export const PaymentNotices = () => {
   const { t } = useTranslation();
   const { data, isError } = utils.loaders.getPaymentNotices();
 
-  console.log(data);
-
   return (
     <>
       <Typography mb={3} variant="h3" component="h1">

--- a/src/routes/PaymentNotices.tsx
+++ b/src/routes/PaymentNotices.tsx
@@ -1,9 +1,8 @@
-import { ErrorOutline } from '@mui/icons-material';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { ButtonNaked } from '@pagopa/mui-italia';
 import { PaymentNotice } from 'components/PaymentNotice';
 import QueryLoader from 'components/QueryLoader';
+import { PaymentNoticesList } from 'components/Skeleton';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import utils from 'utils';
@@ -12,45 +11,32 @@ export const PaymentNotices = () => {
   const { t } = useTranslation();
   const { data, isError } = utils.loaders.getPaymentNotices();
 
+  console.log(data);
+
   return (
-    <Stack height="100%" justifyContent={{ lg: 'space-between' }} component="main">
-      <QueryLoader
-        // TODO: fallback component of behavior be defined
-        fallback={isError && <PaymentNotice.Error />}
-        queryKey="paymentNotices">
-        <Stack gap={5} component="section">
-          <Typography paddingTop={3} variant="h4" component="h1">
-            {t('app.paymentNotices.title')}
-          </Typography>
-          {data.length > 0 ? (
-            <PaymentNotice.List paymentNoticesList={data} />
-          ) : (
-            <PaymentNotice.Empty />
-          )}
-        </Stack>
-        {data?.length > 0 && (
-          <Stack
-            padding={1.3}
-            gap={1}
-            justifyContent="flex-start"
-            marginTop={{ xs: 10, lg: 0 }}
-            component="aside">
-            <Typography variant="body1" component="p">
-              {t('app.paymentNotices.alert.info')}
-            </Typography>
-            <Typography color="error" component="div">
-              <ButtonNaked
-                variant="text"
-                size="medium"
-                color="inherit"
-                startIcon={<ErrorOutline />}
-                aria-label={t('app.paymentNotices.alert.action')}>
-                {t('app.paymentNotices.alert.action')}
-              </ButtonNaked>
-            </Typography>
+    <>
+      <Typography mb={3} variant="h3" component="h1">
+        {t('app.paymentNotices.title')}
+      </Typography>
+      <Stack height="100%" justifyContent={{ lg: 'space-between' }} component="main">
+        <QueryLoader
+          queryKey="paymentNotices"
+          loaderComponent={<PaymentNoticesList />}
+          atLeast={5000}>
+          <Stack gap={5} component="section">
+            {(() => {
+              if (isError || !data) return <PaymentNotice.Error />;
+              if (!data.length) return <PaymentNotice.Empty />;
+              return (
+                <>
+                  <PaymentNotice.List paymentNoticesList={data} />
+                  <PaymentNotice.Info />
+                </>
+              );
+            })()}
           </Stack>
-        )}
-      </QueryLoader>
-    </Stack>
+        </QueryLoader>
+      </Stack>
+    </>
   );
 };

--- a/src/routes/TransactionsList.tsx
+++ b/src/routes/TransactionsList.tsx
@@ -108,19 +108,18 @@ export default function TransactionsListPage() {
           </FormControl>
         </Grid>
       </Grid>
-      <QueryLoader
-        loaderComponent={<TransactionListSkeleton />}
-        fallback={error && <Retry action={refetch} />}
-        queryKey="transactions">
-        {data && data.transactions && data.transactions?.length > 0 ? (
-          <MainContent
-            all={transactions.all}
-            paidByMe={transactions.paidByMe}
-            registeredToMe={transactions.registeredToMe}
-          />
-        ) : (
-          <Empty />
-        )}
+      <QueryLoader loaderComponent={<TransactionListSkeleton />} queryKey="transactions">
+        {(() => {
+          if (error || !data || !data.transactions) return <Retry action={refetch} />;
+          if (data.transactions.length === 0) return <Empty />;
+          return (
+            <MainContent
+              all={transactions.all}
+              paidByMe={transactions.paidByMe}
+              registeredToMe={transactions.registeredToMe}
+            />
+          );
+        })()}
       </QueryLoader>
     </>
   );

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -105,6 +105,7 @@
       "found": "Abbiamo trovato",
       "notice": "avvisi",
       "updated": "Aggiornato il",
+      "loading": "Stiamo cercando tra gli archivi degli enti creditori aderenti al servizio...",
       "alert": {
         "info": "Gli avvisi sono stati recuperati dagli archivi degli enti creditori aderenti al servizio.",
         "action": "Segnala un problema"

--- a/src/utils/loaders.ts
+++ b/src/utils/loaders.ts
@@ -24,49 +24,51 @@ const getTransactionDetails = (id: string) => {
 //   }
 // });
 
-const getPaymentNotices = () => ({
-  isError: false,
-  data: [
-    {
-      payee: {
-        name: 'Politecnico di Milano'
+const getPaymentNotices = () =>
+  useQuery({
+    queryKey: ['paymentNotices'],
+    queryFn: async () => [
+      {
+        payee: {
+          name: 'Politecnico di Milano'
+        },
+        id: 1,
+        paymentInfo: 'RATA 1 - Anno Accademico 2023/2024',
+        amount: '171,00 €',
+        expiringDate: '31/01/2099'
       },
-      id: 1,
-      paymentInfo: 'RATA 1 - Anno Accademico 2023/2024',
-      amount: '171,00 €',
-      expiringDate: '31/01/2099'
-    },
-    {
-      payee: {
-        name: 'Comune di Milano'
+      {
+        payee: {
+          name: 'Comune di Milano'
+        },
+        id: 2,
+        paymentInfo: 'TARI 2024',
+        amount: '171,00 €',
+        expiringDate: '31/01/2099',
+        multiPayment: true
       },
-      id: 2,
-      paymentInfo: 'TARI 2024',
-      amount: '171,00 €',
-      expiringDate: '31/01/2099',
-      multiPayment: true
-    },
-    {
-      payee: {
-        name: 'Comune di Milano'
+      {
+        payee: {
+          name: 'Comune di Milano'
+        },
+        id: 3,
+        paymentInfo: 'Violazione CDS Verbale 0123456',
+        expiringDate: '31/01/2099',
+        amount: '28,70 €',
+        multiPayment: true
       },
-      id: 3,
-      paymentInfo: 'Violazione CDS Verbale 0123456',
-      expiringDate: '31/01/2099',
-      amount: '28,70 €',
-      multiPayment: true
-    },
-    {
-      payee: {
-        name: 'Istituto d’Istruzione Superiore con un nome Molto Lungo che può andare su più righe'
-      },
-      id: 4,
-      paymentInfo: 'Iscrizione Anno Accademico 2023/2024',
-      amount: '171,00 €',
-      expiringDate: '31/01/2099'
-    }
-  ]
-});
+      {
+        payee: {
+          name: 'Istituto d’Istruzione Superiore con un nome Molto Lungo che può andare su più righe'
+        },
+        id: 4,
+        paymentInfo: 'Iscrizione Anno Accademico 2023/2024',
+        amount: '171,00 €',
+        expiringDate: '31/01/2099'
+      }
+    ]
+  });
+
 export default {
   getTransactions,
   getTransactionDetails,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Refactor of the Query Loader component
- Creation of the payment notices skeleton layout 
- Adding a fake loading time to the payment notices page

<!--- Describe your changes in detail -->

#### Motivation and Context

To allow the waiting message to be read (which would be impossible if the API responded very quickly) it is necessary to simulate a minimum waiting time
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally through local development server
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
<img width="626" alt="image" src="https://github.com/pagopa/pagopa-arc-fe/assets/34749257/37d51515-bfad-4899-bd9f-012e1bcfdbb0">

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
